### PR TITLE
Add a phpspec task

### DIFF
--- a/ccabs.main.xml
+++ b/ccabs.main.xml
@@ -33,6 +33,7 @@
     <import file="tasks/phploc/task.xml" />
     <import file="tasks/phpmd/task.xml" />
     <import file="tasks/phpunit/task.xml" />
+    <import file="tasks/phpspec/task.xml" />
     <import file="tasks/travis-configuration-check/task.xml" />
 
     <!-- Build targets from here on. -->
@@ -50,7 +51,7 @@
 
     <target
         name="analyze"
-        depends="phploc, pdepend, phpmd, phpcs, phpcpd, phpunit, branch-alias-validation, travis-configuration-check"
+        depends="phploc, pdepend, phpmd, phpcs, phpcpd, phpunit, phpspec, branch-alias-validation, travis-configuration-check"
         description="Do static analysis of the code"
     />
 <!--

--- a/tasks/phpspec/default.properties
+++ b/tasks/phpspec/default.properties
@@ -1,0 +1,9 @@
+
+# The path of the phpspec binary.
+ccabs.bin.phpspec = ${ccabs.bin.dir}/phpspec
+
+# The format for displaying the help output.
+ccabs.phpspec.format =
+
+# An alternative config file.
+ccabs.phpspec.config =

--- a/tasks/phpspec/docmentation.md
+++ b/tasks/phpspec/docmentation.md
@@ -1,0 +1,11 @@
+CCABS task phpspec
+==================
+
+This task executes [phpspec](http://www.phpspec.net) on you code base.  
+
+Utilized properties
+------------------
+
+ * `ccabs.bin.phpspec` the path to the phpspec executable (default: `${ccabs.bin.dir}/phpspec`)
+ * `ccabs.phpspec.config` optional and custom location for the configuration file`
+ * `ccabs.phpspec.format` optional formatter to output help in another format

--- a/tasks/phpspec/task.xml
+++ b/tasks/phpspec/task.xml
@@ -1,0 +1,19 @@
+<project name="ccabs.task.phpspec">
+    <property file="${ccabs.basedir}/tasks/phpspec/default.properties"/>
+    <condition property="ccabs.phpspec.arg.format" value="" else="--format=${ccabs.phpspec.format}">
+        <equals arg1="${ccabs.phpspec.format}" arg2="" />
+    </condition>
+    <condition property="ccabs.phpspec.arg.config" value="" else="--config=${ccabs.phpspec.config}">
+        <equals arg1="${ccabs.phpspec.config}" arg2="" />
+    </condition>
+    <target name="-check-phpspec.installed" unless="phpspec.installed">
+        <available property="phpspec.installed" file="${ccabs.bin.phpspec}"/>
+    </target>
+    <target name="phpspec" depends="-check-phpspec.installed" if="${phpspec.installed}">
+        <exec dir="${basedir}" executable="${ccabs.bin.phpspec}" failonerror="true" taskname="phpspec">
+            <arg value="run" />
+            <arg line="${ccabs.phpspec.arg.config}" />
+            <arg line="${ccabs.phpspec.arg.format}" />
+        </exec>
+    </target>
+</project>


### PR DESCRIPTION
I'm rather use [phpspec](http://www.phpspec.net) instead of phpunit. It would be great if the build system supports in by default.

I've implemented my own task in https://github.com/netzmacht/contao-build-tools/tree/master/tasks/phpspec. This PR offers to be included into ccabs.
