### PR TITLE
Fix phpcq using paths with spaces

### DIFF
--- a/tasks/author-validation/task.xml
+++ b/tasks/author-validation/task.xml
@@ -15,7 +15,7 @@
     <target name="author-validation" depends="-check-author-validation.installed" if="${author-validation.installed}">
         <exec dir="${basedir}" executable="${phpcq.bin.author-validation}" failonerror="true" taskname="author-validation">
             <arg line="${author-validation.arguments}"/>
-            <arg line="${basedir}"/>
+            <arg value="${basedir}"/>
         </exec>
     </target>
 </project>

--- a/tasks/autoload-validation/task.xml
+++ b/tasks/autoload-validation/task.xml
@@ -5,7 +5,7 @@
     </target>
     <target name="autoload-validation" depends="-check-autoload-validation.installed" if="${autoload-validation.installed}">
         <exec dir="${basedir}" executable="${phpcq.bin.autoload-validation}" failonerror="true" taskname="autoload-validation">
-            <arg line="${basedir}"/>
+            <arg value="${basedir}"/>
         </exec>
     </target>
 </project>

--- a/tasks/branch-alias-validation/task.xml
+++ b/tasks/branch-alias-validation/task.xml
@@ -5,7 +5,7 @@
     </target>
     <target name="branch-alias-validation" depends="-check-branch-alias-validation.installed" if="${branch-alias-validation.installed}">
         <exec dir="${basedir}" executable="${phpcq.bin.validate-branch-alias}" failonerror="true" taskname="branch-alias-validation">
-            <arg line="${basedir}"/>
+            <arg value="${basedir}"/>
         </exec>
     </target>
 </project>

--- a/tasks/pdepend/documentation.md
+++ b/tasks/pdepend/documentation.md
@@ -3,7 +3,7 @@ PHPCQ task pdepend
 
 Calculate software metrics using PHP_Depend.
 
-This task executes [pdepend](https://http://pdepend.org/) on your code base.
+This task executes [pdepend](https://pdepend.org/) on your code base.
 
 Utilized properties
 -------------------

--- a/tasks/phpcs/task.xml
+++ b/tasks/phpcs/task.xml
@@ -13,7 +13,7 @@
     </target>
     <target name="phpcs" depends="-check-phpcs.installed" if="${phpcs.installed}">
         <exec dir="${basedir}" executable="${phpcq.bin.phpcs}" failonerror="true" taskname="phpcs">
-            <arg line="--standard=${phpcs.standard}"/>
+            <arg value="--standard=${phpcs.standard}"/>
             <arg line="${phpcs.customflags}"/>
             <arg line="${phpcs.excluded.arguments}"/>
             <arg line="${phpcs.src}"/>

--- a/tasks/phpmd/task.xml
+++ b/tasks/phpmd/task.xml
@@ -18,7 +18,7 @@
         <exec dir="${basedir}" executable="${phpcq.bin.phpmd}" failonerror="true" taskname="phpmd">
             <arg line="${phpmd.dirs}"/>
             <arg line="${phpmd.format}"/>
-            <arg line="${phpmd.ruleset}"/>
+            <arg value="${phpmd.ruleset}"/>
             <arg line="${phpmd.excluded.arguments}"/>
             <arg line="${phpmd.customflags}"/>
         </exec>

--- a/tasks/phpunit/documentation.md
+++ b/tasks/phpunit/documentation.md
@@ -1,7 +1,7 @@
 PHPCQ task phpunit
 ==================
 
-This task executes [phpunit](https://github.com/squizlabs/PHP_CodeSniffer) on your code base.
+This task executes [phpunit](https://phpunit.de/) on your code base.
 
 Requirements
 ------------

--- a/tasks/travis-configuration-check/documentation.md
+++ b/tasks/travis-configuration-check/documentation.md
@@ -1,7 +1,7 @@
 PHPCQ travis-configuration-check
 ================================
 
-This task executes [phpcs](https://github.com/phpcq/travis-configuration-check) on
+This task executes [travis-configuration-check](https://github.com/phpcq/travis-configuration-check) on
 your repository.
 
 Utilized properties

--- a/tasks/travis-configuration-check/task.xml
+++ b/tasks/travis-configuration-check/task.xml
@@ -5,7 +5,7 @@
     </target>
     <target name="travis-configuration-check" depends="-travis-configuration-check.installed" if="${travis-configuration-check.installed}">
         <exec dir="${basedir}" executable="${phpcq.bin.check-travis-configuration}" failonerror="true" taskname="travis-configuration-check">
-            <arg line="${basedir}"/>
+            <arg value="${basedir}"/>
             <arg line="${travis-configuration-check.customflags}"/>
         </exec>
     </target>


### PR DESCRIPTION
When the basedir contains some spaces phpcq does not work bacause **ant** would split the value for each space. Switching to `<arg value="">` solves the issue for me.

More information for example here:
https://mikaelsitruk.wordpress.com/2009/08/28/ant-tip-handling-space-in-exec-task/