### PR TITLE
Load plugins via installed.json instead of Finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "composer/xdebug-handler": "^1.4",
         "symfony/config": "^5.0.7",
         "symfony/console": "^5.0.7",
-        "symfony/finder": "^5.0.7",
         "symfony/process": "^5.0.7",
         "symfony/yaml": "^5.0.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94b49077aaf5d2c5e99a2733d90f1b41",
+    "content-hash": "08d39b9e33c7f17e839d99a15356b1e7",
     "packages": [
         {
             "name": "composer/semver",
@@ -428,69 +428,6 @@
                 }
             ],
             "description": "Symfony Filesystem Component",
-            "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-03-27T16:56:45+00:00"
-        },
-        {
-            "name": "symfony/finder",
-            "version": "v5.0.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "600a52c29afc0d1caa74acbec8d3095ca7e9910d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/600a52c29afc0d1caa74acbec8d3095ca7e9910d",
-                "reference": "600a52c29afc0d1caa74acbec8d3095ca7e9910d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "funding": [
                 {

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -79,7 +79,7 @@ final class RunCommand extends AbstractCommand
         // Create build configuration
         $buildConfig = new BuildConfiguration($projectConfig, $taskFactory, sys_get_temp_dir());
         // Load bootstraps
-        $plugins = PluginRegistry::buildFromPath($phpcqPath);
+        $plugins = PluginRegistry::buildFromInstalledJson($phpcqPath . '/installed.json');
 
         if ($toolName = $input->getArgument('tool')) {
             assert(is_string($toolName));

--- a/src/Command/ValidateCommand.php
+++ b/src/Command/ValidateCommand.php
@@ -40,7 +40,7 @@ final class ValidateCommand extends AbstractCommand
         assert(is_string($configFile));
         $config     = ConfigLoader::load($configFile);
 
-        $plugins = PluginRegistry::buildFromPath($phpcqPath);
+        $plugins = PluginRegistry::buildFromInstalledJson($phpcqPath . '/installed.json');
         $valid   = true;
 
         $output->writeln('Validate plugins:', OutputInterface::VERBOSITY_VERY_VERBOSE);

--- a/src/Plugin/PluginRegistry.php
+++ b/src/Plugin/PluginRegistry.php
@@ -2,10 +2,10 @@
 
 namespace Phpcq\Plugin;
 
+use Generator;
 use IteratorAggregate;
+use LogicException;
 use Phpcq\Exception\RuntimeException;
-use Symfony\Component\Finder\Finder;
-use function assert;
 use function get_class;
 
 final class PluginRegistry implements IteratorAggregate
@@ -13,17 +13,17 @@ final class PluginRegistry implements IteratorAggregate
     /** @var array<string, PluginInterface> */
     private $plugins = [];
 
-    public static function buildFromPath(string $pluginPath): self
+    public static function buildFromInstalledJson(string $installedJson): self
     {
         $instance = new self();
 
-        foreach (Finder::create()->in($pluginPath)->name('*.php')->getIterator() as $fileInfo) {
+        foreach (self::getBootstrapFileNames($installedJson) as $filePath) {
             /**
              * @psalm-suppress UnresolvableInclude
              *
              * @var PluginInterface
              */
-            $plugin = require $fileInfo->getRealPath();
+            $plugin = require_once $filePath;
             if (!$plugin instanceof PluginInterface) {
                 throw new RuntimeException('Not a valid plugin: ' . get_class($plugin));
             }
@@ -55,5 +55,33 @@ final class PluginRegistry implements IteratorAggregate
     public function getIterator(): iterable
     {
         yield from $this->plugins;
+    }
+
+    private static function getBootstrapFileNames(string $jsonFile): Generator
+    {
+        $realFile = realpath($jsonFile);
+        if (false === $realFile || !is_readable($realFile)) {
+            throw new RuntimeException('Invalid path provided: ' . $jsonFile);
+        }
+        $baseDir  = dirname($realFile);
+        $contents = json_decode(file_get_contents($jsonFile), true);
+        foreach ($contents['phars'] as $toolName => $toolVersions) {
+            if (count($toolVersions) > 1) {
+                throw new LogicException('Tool ' . $toolName . ' has multiple versions installed.');
+            }
+
+            $version   = $toolVersions[0];
+            $bootstrap = $version['bootstrap'];
+            if (!is_array($bootstrap) || 'file' !== $bootstrap['type']) {
+                throw new RuntimeException('Invalid bootstrap definition: ' . json_encode($bootstrap));
+            }
+            // Bootstrap files are in the same dir as the installed.json.
+            $path = realpath($baseDir . '/' . $bootstrap['url']);
+            if (false === $path || !is_readable($path)) {
+                throw new RuntimeException('Invalid bootstrap path provided for tool ' . $toolName . ': ' . $bootstrap['url']);
+            }
+
+            yield $path;
+        }
     }
 }


### PR DESCRIPTION
This also replaces `PluginRegistry::buildFromPath` with
`PluginRegistry::buildFromInstalledJson`.
This fixes the first step of #22