### PR TITLE
[RFC] Run phar tool directly

### DIFF
--- a/phpcq
+++ b/phpcq
@@ -1,11 +1,13 @@
 #!/usr/bin/env php
 <?php
 
+use Phpcq\Command\ExecCommand;
 use Phpcq\Command\PlatformInformationCommand;
 use Phpcq\Command\RunCommand;
 use Phpcq\Command\UpdateCommand;
 use Phpcq\Command\ValidateCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
 
 error_reporting(E_ALL & ~ E_USER_DEPRECATED);
 
@@ -27,7 +29,32 @@ $application->addCommands([
     new UpdateCommand(),
     new ValidateCommand(),
     new PlatformInformationCommand(),
+    new ExecCommand()
 ]);
 
+$argv = $_SERVER['argv'];
+$input = new ArgvInput($argv);
+if ($input->getFirstArgument() === 'exec') {
+    $application->setDefaultCommand('exec', true);
+    // strip the application name.
+    array_shift($argv);
+    // If no '--' is to be found in the args (used to separate options for phpcq from the args and options for the tool,
+    // insert it just before the tool name.
+    if (false === array_search('--', $argv)) {
+        $argPos = array_search('exec', $argv);
+        $tempInput = new ArgvInput(array_slice($argv, $argPos + 1));
+        if (null !== $toolName = $tempInput->getFirstArgument()) {
+            $toolPos = array_search($toolName, $argv);
+            $argv = array_merge(
+                array_slice($argv, 0, $argPos),
+                array_slice($argv, $argPos + 1, $toolPos - ($argPos + 1)),
+                ['--'],
+                array_slice($argv, $toolPos)
+            );
+        }
+    }
+    $input = new ArgvInput($argv);
+}
+
 $application->setAutoExit(true);
-$application->run();
+$application->run($input);

--- a/phpcq
+++ b/phpcq
@@ -35,24 +35,10 @@ $application->addCommands([
 $argv = $_SERVER['argv'];
 $input = new ArgvInput($argv);
 if ($input->getFirstArgument() === 'exec') {
-    $application->setDefaultCommand('exec', true);
+    $argv = ExecCommand::prepare($argv);
     // strip the application name.
     array_shift($argv);
-    // If no '--' is to be found in the args (used to separate options for phpcq from the args and options for the tool,
-    // insert it just before the tool name.
-    if (false === array_search('--', $argv)) {
-        $argPos = array_search('exec', $argv);
-        $tempInput = new ArgvInput(array_slice($argv, $argPos + 1));
-        if (null !== $toolName = $tempInput->getFirstArgument()) {
-            $toolPos = array_search($toolName, $argv);
-            $argv = array_merge(
-                array_slice($argv, 0, $argPos),
-                array_slice($argv, $argPos + 1, $toolPos - ($argPos + 1)),
-                ['--'],
-                array_slice($argv, $toolPos)
-            );
-        }
-    }
+    $application->setDefaultCommand('exec', true);
     $input = new ArgvInput($argv);
 }
 

--- a/src/Command/ExecCommand.php
+++ b/src/Command/ExecCommand.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpcq\Command;
+
+use Phpcq\Exception\RuntimeException;
+use Phpcq\FileDownloader;
+use Phpcq\Output\BufferedOutput;
+use Phpcq\Output\SymfonyConsoleOutput;
+use Phpcq\Output\SymfonyOutput;
+use Phpcq\Platform\PlatformInformation;
+use Phpcq\Repository\JsonRepositoryLoader;
+use Phpcq\Repository\RepositoryInterface;
+use Phpcq\Task\TaskFactory;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
+use function assert;
+use function is_string;
+
+final class ExecCommand extends AbstractCommand
+{
+    protected function configure(): void
+    {
+        $this->setName('exec')->setDescription('Execute a tool with the passed arguments');
+
+        $this->addArgument(
+            'tool',
+            InputArgument::REQUIRED,
+            'The tool to be run'
+        );
+
+        $this->addArgument(
+            'args',
+            InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+            'Optional options and arguments to pass to the tool'
+        );
+
+        parent::configure();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $phpcqPath = $input->getOption('tools');
+        assert(is_string($phpcqPath));
+        $this->createDirectory($phpcqPath);
+        $cachePath = $input->getOption('cache');
+        assert(is_string($cachePath));
+        $this->createDirectory($cachePath);
+
+        if ($output->isVeryVerbose()) {
+            $output->writeln('Using HOME: ' . $phpcqPath);
+            $output->writeln('Using CACHE: ' . $cachePath);
+        }
+
+        /** @psalm-suppress PossiblyInvalidArgument */
+        $taskFactory = new TaskFactory(
+            $phpcqPath,
+            $this->getInstalledRepository($phpcqPath, $cachePath),
+            ...$this->findPhpCli()
+        );
+
+        $toolName = $input->getArgument('tool');
+        assert(is_string($toolName));
+
+        /** @var array $toolArguments */
+        $toolArguments = $input->getArgument('args');
+        $task = $taskFactory
+            ->buildRunPhar($toolName, $toolArguments)
+            ->withWorkingDirectory(getcwd())
+            ->build();
+
+        // Wrap console output
+        if ($output instanceof ConsoleOutputInterface) {
+            $consoleOutput = new SymfonyConsoleOutput($output);
+        } else {
+            $consoleOutput = new SymfonyOutput($output);
+        }
+
+        // Execute task.
+        $exitCode = 0;
+        $taskOutput = new BufferedOutput($consoleOutput);
+        try {
+            $task->run($taskOutput);
+        } catch (RuntimeException $throwable) {
+            $taskOutput->writeln($throwable->getMessage(), SymfonyOutput::VERBOSITY_NORMAL, SymfonyOutput::CHANNEL_STRERR);
+            $taskOutput->release();
+            return (int) $throwable->getCode();
+        }
+        $taskOutput->release();
+
+        return $exitCode;
+    }
+
+    private function getInstalledRepository(string $phpcqPath, string $cachePath): RepositoryInterface
+    {
+        if (!is_file($phpcqPath . '/installed.json')) {
+            throw new RuntimeException('Please install the tools first ("phpcq update").');
+        }
+        $loader = new JsonRepositoryLoader(
+            PlatformInformation::createFromCurrentPlatform(),
+            new FileDownloader($cachePath)
+        );
+
+        return $loader->loadFile($phpcqPath . '/installed.json');
+    }
+
+    /** @psalm-return array{0: string, 1: array} */
+    private function findPhpCli(): array
+    {
+        $finder     = new PhpExecutableFinder();
+        $executable = $finder->find();
+
+        if (!is_string($executable)) {
+            throw new RuntimeException('PHP executable not found');
+        }
+
+        return [$executable, $finder->findArguments()];
+    }
+}

--- a/tests/Command/ExecCommandTest.php
+++ b/tests/Command/ExecCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpcq\Test\Command;
+
+use Phpcq\Command\ExecCommand;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Phpcq\Command\ExecCommand
+ */
+class ExecCommandTest extends TestCase
+{
+    public function prepareProvider(): array
+    {
+        return [
+            'missing tool name' => [
+                'expected' => ['/path/to/phpcq', 'exec'],
+                'argv'     => ['/path/to/phpcq', 'exec'],
+            ],
+            'plain exec command' => [
+                'expected' => ['/path/to/phpcq', 'exec', '--', 'phpunit'],
+                'argv'     => ['/path/to/phpcq', 'exec', 'phpunit'],
+            ],
+            'phpcq options' => [
+                'expected' => ['/path/to/phpcq', 'exec', '-q', '--', 'phpunit'],
+                'argv'     => ['/path/to/phpcq', 'exec', '-q', 'phpunit'],
+            ],
+            'prefix options for phpcq and suffix option(s) for tool' => [
+                'expected' => ['/path/to/phpcq', 'exec', '-q', '--', 'phpunit', '--help'],
+                'argv'     => ['/path/to/phpcq', 'exec', '-q', 'phpunit', '--help'],
+            ],
+            '"--" already provided' => [
+                'expected' => ['/path/to/phpcq', 'exec', '-q', '--', 'phpunit', '--help'],
+                'argv'     => ['/path/to/phpcq', 'exec', '-q', '--', 'phpunit', '--help'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider prepareProvider
+     */
+    public function testPreparesInputCorrectly(array $expected, array $argv): void
+    {
+        $this->assertSame($expected, ExecCommand::prepare($argv));
+    }
+}


### PR DESCRIPTION
This allows to execute phar files directly via CLI.

usage:
```
Description:
  Execute a tool with the passed arguments

Usage:
  exec [options] [--] <tool> [<args>...]

Arguments:
  tool                  The tool to be run
  args                  Optional options and arguments to pass to the tool

Options:
  -c, --config=CONFIG   The configuration file to use [default: ".../.phpcq.yaml"]
  -t, --tools=TOOLS     Path to the phpcq tool directory [default: ".../vendor/phpcq"]
  -x, --cache=CACHE     Path to the phpcq cache directory [default: ".../.cache/phpcq"]
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```