### PR TITLE
[RFC] Feature/ignore platform reqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
         || echo dev-${TRAVIS_BRANCH}) \
         travis_retry composer update $COMPOSER_FLAGS $PLATFORM_FLAGS --prefer-dist --no-interaction;
     fi
-  - ./phpcq update
+  - ./phpcq update $PLATFORM_FLAGS
 
 script:
-  - ./phpcq run
+  - ./phpcq run $PLATFORM_FLAGS
 
 # Hack to make things work again - we can not use a shallow repository.
 git:

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -72,6 +72,12 @@ abstract class AbstractCommand extends Command
             'Path to the phpcq tool directory',
             getcwd() . '/vendor/phpcq'
         );
+        $this->addOption(
+            'ignore-platform-reqs',
+            null,
+            InputOption::VALUE_NONE,
+            'Ignore platform requirements (php & ext- packages).'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace Phpcq\Command;
 
+use Phpcq\ConfigLoader;
 use Phpcq\Exception\RuntimeException;
+use Phpcq\Output\SymfonyConsoleOutput;
+use Phpcq\Output\SymfonyOutput;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use function getcwd;
 use function is_dir;
 use function mkdir;
@@ -14,6 +20,42 @@ use function sprintf;
 
 abstract class AbstractCommand extends Command
 {
+    /**
+     * Only valid when examined from within doExecute().
+     *
+     * @var InputInterface
+     *
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
+    protected $input;
+
+    /**
+     * Only valid when examined from within doExecute().
+     *
+     * @var OutputInterface
+     *
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
+    protected $output;
+
+    /**
+     * Only valid when examined from within doExecute().
+     *
+     * @var string
+     *
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
+    protected $phpcqPath;
+
+    /**
+     * Only valid when examined from within doExecute().
+     *
+     * @var array
+     *
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
+    protected $config;
+
     protected function configure(): void
     {
         $this->addOption(
@@ -32,6 +74,22 @@ abstract class AbstractCommand extends Command
         );
     }
 
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input  = $input;
+        $this->output = $output;
+
+        $this->phpcqPath = $this->determinePhpcqPath();
+
+        $configFile = $this->input->getOption('config');
+        assert(is_string($configFile));
+        $this->config = ConfigLoader::load($configFile);
+
+        return $this->doExecute();
+    }
+
+    protected abstract function doExecute(): int;
+
     /**
      * Create a directory if not exists.
      *
@@ -48,5 +106,26 @@ abstract class AbstractCommand extends Command
         if (!mkdir($path, 0777, true)) {
             throw new RuntimeException(sprintf('Directory "%s" was not created', $path));
         }
+    }
+
+    protected function getWrappedOutput(): \Phpcq\PluginApi\Version10\OutputInterface
+    {
+        // Wrap console output
+        if ($this->output instanceof ConsoleOutputInterface) {
+            return new SymfonyConsoleOutput($this->output);
+        }
+        return new SymfonyOutput($this->output);
+    }
+
+    private function determinePhpcqPath(): string
+    {
+        $phpcqPath = $this->input->getOption('tools');
+        assert(is_string($phpcqPath));
+        $this->createDirectory($phpcqPath);
+        if ($this->output->isVeryVerbose()) {
+            $this->output->writeln('Using HOME: ' . $phpcqPath);
+        }
+
+        return $phpcqPath;
     }
 }

--- a/src/Command/InstalledRepositoryLoadingCommandTrait.php
+++ b/src/Command/InstalledRepositoryLoadingCommandTrait.php
@@ -12,9 +12,10 @@ use Phpcq\Repository\RepositoryInterface;
 
 trait InstalledRepositoryLoadingCommandTrait
 {
-    private function getInstalledRepository(string $phpcqPath, bool $failIfNotExist = true): RepositoryInterface
-    {
-        if (!is_file($phpcqPath . '/installed.json')) {
+    private function getInstalledRepository(
+        bool $failIfNotExist
+    ): RepositoryInterface {
+        if (!is_file($this->phpcqPath . '/installed.json')) {
             if (!$failIfNotExist) {
                 return new Repository(PlatformInformation::createFromCurrentPlatform());
             }
@@ -22,6 +23,6 @@ trait InstalledRepositoryLoadingCommandTrait
         }
         $loader = new InstalledRepositoryLoader(PlatformInformation::createFromCurrentPlatform());
 
-        return $loader->loadFile($phpcqPath . '/installed.json');
+        return $loader->loadFile($this->phpcqPath . '/installed.json');
     }
 }

--- a/src/Command/InstalledRepositoryLoadingCommandTrait.php
+++ b/src/Command/InstalledRepositoryLoadingCommandTrait.php
@@ -5,23 +5,26 @@ declare(strict_types=1);
 namespace Phpcq\Command;
 
 use Phpcq\Exception\RuntimeException;
-use Phpcq\Platform\PlatformInformation;
+use Phpcq\Platform\PlatformRequirementChecker;
 use Phpcq\Repository\InstalledRepositoryLoader;
 use Phpcq\Repository\Repository;
 use Phpcq\Repository\RepositoryInterface;
 
 trait InstalledRepositoryLoadingCommandTrait
 {
-    private function getInstalledRepository(
-        bool $failIfNotExist
-    ): RepositoryInterface {
+    private function getInstalledRepository(bool $failIfNotExist): RepositoryInterface {
+        $requirementChecker = null;
+        if (!$this->input->hasOption('ignore-platform-reqs') || !$this->input->getOption('ignore-platform-reqs')) {
+            $requirementChecker = PlatformRequirementChecker::create();
+        }
+
         if (!is_file($this->phpcqPath . '/installed.json')) {
             if (!$failIfNotExist) {
-                return new Repository(PlatformInformation::createFromCurrentPlatform());
+                return new Repository($requirementChecker);
             }
             throw new RuntimeException('Please install the tools first ("phpcq update").');
         }
-        $loader = new InstalledRepositoryLoader(PlatformInformation::createFromCurrentPlatform());
+        $loader = new InstalledRepositoryLoader($requirementChecker);
 
         return $loader->loadFile($this->phpcqPath . '/installed.json');
     }

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -4,19 +4,13 @@ declare(strict_types=1);
 
 namespace Phpcq\Command;
 
-use Phpcq\ConfigLoader;
 use Phpcq\FileDownloader;
-use Phpcq\Output\SymfonyConsoleOutput;
-use Phpcq\Output\SymfonyOutput;
 use Phpcq\Platform\PlatformInformation;
 use Phpcq\Repository\JsonRepositoryLoader;
 use Phpcq\Repository\RepositoryFactory;
 use Phpcq\ToolUpdate\UpdateCalculator;
 use Phpcq\ToolUpdate\UpdateExecutor;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\ConsoleOutputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use function assert;
 use function is_string;
 
@@ -44,48 +38,36 @@ final class UpdateCommand extends AbstractCommand
         parent::configure();
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecute(): int
     {
-        $phpcqPath = $input->getOption('tools');
-        assert(is_string($phpcqPath));
-        $this->createDirectory($phpcqPath);
-
-        $cachePath = $input->getOption('cache');
+        $cachePath = $this->input->getOption('cache');
         assert(is_string($cachePath));
         $this->createDirectory($cachePath);
 
-        if ($output->isVeryVerbose()) {
-            $output->writeln('Using HOME: ' . $phpcqPath);
-            $output->writeln('Using CACHE: ' . $cachePath);
+        if ($this->output->isVeryVerbose()) {
+            $this->output->writeln('Using CACHE: ' . $cachePath);
         }
 
         $platformInformation = PlatformInformation::createFromCurrentPlatform();
-        $configFile       = $input->getOption('config');
-        assert(is_string($configFile));
-        $config           = ConfigLoader::load($configFile);
-        $downloader       = new FileDownloader($cachePath, $config['auth'] ?? []);
+
+        $downloader       = new FileDownloader($cachePath, $this->config['auth'] ?? []);
         $repositoryLoader = new JsonRepositoryLoader($platformInformation, $downloader, true);
         $factory          = new RepositoryFactory($repositoryLoader);
         // Download repositories
-        $pool = $factory->buildPool($config['repositories'] ?? []);
+        $pool = $factory->buildPool($this->config['repositories'] ?? []);
 
-        // Wrap console output
-        if ($output instanceof ConsoleOutputInterface) {
-            $consoleOutput = new SymfonyConsoleOutput($output);
-        } else {
-            $consoleOutput = new SymfonyOutput($output);
-        }
+        $consoleOutput = $this->getWrappedOutput();
 
-        $calculator = new UpdateCalculator($this->getInstalledRepository($phpcqPath, false), $pool, $consoleOutput);
-        $tasks = $calculator->calculate($config['tools']);
+        $calculator = new UpdateCalculator($this->getInstalledRepository(false), $pool, $consoleOutput);
+        $tasks = $calculator->calculate($this->config['tools']);
 
-        if ($input->getOption('dry-run')) {
+        if ($this->input->getOption('dry-run')) {
             foreach ($tasks as $task) {
-                $output->writeln($task['message']);
+                $this->output->writeln($task['message']);
             }
             return 0;
         }
-        $executor = new UpdateExecutor($platformInformation, $downloader, $phpcqPath, $consoleOutput);
+        $executor = new UpdateExecutor($platformInformation, $downloader, $this->phpcqPath, $consoleOutput);
         $executor->execute($tasks);
 
         return 0;

--- a/src/Platform/PlatformInformation.php
+++ b/src/Platform/PlatformInformation.php
@@ -127,6 +127,11 @@ class PlatformInformation implements PlatformInformationInterface
 
             $reflExt = new \ReflectionExtension($name);
             $prettyVersion = $reflExt->getVersion();
+            // "ext-mysqlnd" has an obscure version string: "mysqlnd 7.4.4".
+            // See: https://github.com/php/php-src/blob/1c334db4c818eb4175e9e246f3fc5d91bcfe1eef/ext/mysqlnd/mysqlnd.h#L22
+            if (0 === strncmp($prettyVersion, 'mysqlnd ', 8)) {
+                $prettyVersion = substr($prettyVersion, 8);
+            }
 
             $extensions['ext-' . strtolower($name)] = $prettyVersion;
         }

--- a/src/Platform/PlatformInformation.php
+++ b/src/Platform/PlatformInformation.php
@@ -127,10 +127,17 @@ class PlatformInformation implements PlatformInformationInterface
 
             $reflExt = new \ReflectionExtension($name);
             $prettyVersion = $reflExt->getVersion();
-            // "ext-mysqlnd" has an obscure version string: "mysqlnd 7.4.4".
-            // See: https://github.com/php/php-src/blob/1c334db4c818eb4175e9e246f3fc5d91bcfe1eef/ext/mysqlnd/mysqlnd.h#L22
+            // "ext-mysqlnd" has an obscure version string:
+            // - since PHP 7.4.0: "mysqlnd 7.4.4"
+            // - pre PHP 7.4.0: "mysqlnd 5.0.12-dev - 20150407 - $Id$"
+            // See:
+            // - https://github.com/php/php-src/blob/1c334db4c818eb4175e9e246f3fc5d91bcfe1eef/ext/mysqlnd/mysqlnd.h#L22
+            // - https://github.com/php/php-src/blob/da1816c3d37da03c62d0086e6228625ac006abec/ext/mysqlnd/mysqlnd.h#L24
+            // We use strncmp here to be able to skip the heavy regex calculation for all other extensions.
             if (0 === strncmp($prettyVersion, 'mysqlnd ', 8)) {
-                $prettyVersion = substr($prettyVersion, 8);
+                if (preg_match('#mysqlnd ([^ ]*)#', $prettyVersion, $matches)) {
+                    $prettyVersion = $matches[1];
+                }
             }
 
             $extensions['ext-' . strtolower($name)] = $prettyVersion;

--- a/src/Platform/PlatformRequirementChecker.php
+++ b/src/Platform/PlatformRequirementChecker.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpcq\Platform;
+
+use Closure;
+use Composer\Semver\Constraint\Constraint;
+use Composer\Semver\VersionParser;
+
+class PlatformRequirementChecker implements PlatformRequirementCheckerInterface
+{
+    /**
+     * @var Closure
+     */
+    private $callback;
+
+    public static function create(?PlatformInformationInterface $platformInformation = null): self
+    {
+        $platformInformation = $platformInformation ?? PlatformInformation::createFromCurrentPlatform();
+
+        $parser = new VersionParser();
+        return new self(function (string $name, string $constraint) use ($platformInformation, $parser): bool {
+            $installedVersion = $platformInformation->getInstalledVersion($name);
+
+            // Requirement is not available
+            if (null === $installedVersion) {
+                return false;
+            }
+            $constraints = $parser->parseConstraints($constraint);
+
+            return $constraints->matches(new Constraint('=', $parser->normalize($installedVersion)));
+        });
+    }
+
+    public static function createAlwaysFulfilling(): self
+    {
+        return new self(function (): bool {
+            return true;
+        });
+    }
+
+    private function __construct(Closure $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function isFulfilled(string $name, string $constraint): bool
+    {
+        return ($this->callback)($name, $constraint);
+    }
+}

--- a/src/Platform/PlatformRequirementCheckerInterface.php
+++ b/src/Platform/PlatformRequirementCheckerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpcq\Platform;
+
+interface PlatformRequirementCheckerInterface
+{
+    public function isFulfilled(string $name, string $constraint): bool;
+}

--- a/src/Repository/InstalledRepositoryLoader.php
+++ b/src/Repository/InstalledRepositoryLoader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phpcq\Repository;
 
 use Phpcq\Exception\RuntimeException;
-use Phpcq\Platform\PlatformInformationInterface;
+use Phpcq\Platform\PlatformRequirementCheckerInterface;
 
 /**
  * Load a installed.json file.
@@ -20,23 +20,23 @@ class InstalledRepositoryLoader
     private $repository;
 
     /**
-     * @var PlatformInformationInterface
+     * @var PlatformRequirementCheckerInterface|null
      */
-    private $platformInformation;
+    private $requirementChecker;
 
     /**
      * Create a new instance.
      *
-     * @param PlatformInformationInterface $platformInformation
+     * @param PlatformRequirementCheckerInterface|null $requirementChecker
      */
-    public function __construct(PlatformInformationInterface $platformInformation)
+    public function __construct(?PlatformRequirementCheckerInterface $requirementChecker)
     {
-        $this->platformInformation = $platformInformation;
+        $this->requirementChecker = $requirementChecker;
     }
 
     public function loadFile(string $filePath, ?string $baseDir = null): RepositoryInterface
     {
-        $this->repository = new Repository($this->platformInformation);
+        $this->repository = new Repository($this->requirementChecker);
         $fileName         = basename($filePath);
         $baseDir          = $baseDir ?? dirname($filePath);
         $data             = $this->readFile($fileName, $baseDir);

--- a/src/Repository/JsonRepositoryLoader.php
+++ b/src/Repository/JsonRepositoryLoader.php
@@ -6,7 +6,7 @@ namespace Phpcq\Repository;
 
 use Phpcq\Exception\RuntimeException;
 use Phpcq\FileDownloader;
-use Phpcq\Platform\PlatformInformationInterface;
+use Phpcq\Platform\PlatformRequirementCheckerInterface;
 
 /**
  * Load a json file.
@@ -31,27 +31,27 @@ class JsonRepositoryLoader
     private $bypassCache;
 
     /**
-     * @var PlatformInformationInterface
+     * @var PlatformRequirementCheckerInterface|null
      */
-    private $platformInformation;
+    private $requirementChecker;
 
     /**
      * Create a new instance.
      *
-     * @param PlatformInformationInterface $platformInformation
-     * @param FileDownloader $downloader
-     * @param bool $bypassCache
+     * @param PlatformRequirementCheckerInterface|null $requirementChecker
+     * @param FileDownloader                           $downloader
+     * @param bool                                     $bypassCache
      */
-    public function __construct(PlatformInformationInterface $platformInformation, FileDownloader $downloader, bool $bypassCache = false)
+    public function __construct(?PlatformRequirementCheckerInterface $requirementChecker, FileDownloader $downloader, bool $bypassCache = false)
     {
-        $this->platformInformation = $platformInformation;
+        $this->requirementChecker = $requirementChecker;
         $this->downloader = $downloader;
         $this->bypassCache = $bypassCache;
     }
 
     public function loadFile(string $filePath, ?array $hash = null, ?string $baseDir = null): RepositoryInterface
     {
-        $this->repository = new Repository($this->platformInformation);
+        $this->repository = new Repository($this->requirementChecker);
         $baseDir          = $baseDir ?? dirname($filePath);
         $data             = $this->downloader->downloadJsonFile($filePath, $baseDir, $this->bypassCache, $hash);
         $bootstrapLookup  = $data['bootstraps'] ?? [];

--- a/src/ToolUpdate/UpdateCalculator.php
+++ b/src/ToolUpdate/UpdateCalculator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phpcq\ToolUpdate;
 
-use Phpcq\Platform\PlatformInformation;
 use Phpcq\PluginApi\Version10\OutputInterface;
 use Phpcq\Repository\Repository;
 use Phpcq\Repository\RepositoryInterface;
@@ -44,7 +43,7 @@ final class UpdateCalculator
 
     private function calculateDesiredTools(array $tools): RepositoryInterface
     {
-        $desired = new Repository(PlatformInformation::createFromCurrentPlatform());
+        $desired = new Repository();
         foreach ($tools as $toolName => $tool) {
             $desired->addVersion($toolVersion = $this->pool->getTool($toolName, $tool['version']));
             $this->output->writeln(

--- a/src/ToolUpdate/UpdateExecutor.php
+++ b/src/ToolUpdate/UpdateExecutor.php
@@ -6,7 +6,6 @@ namespace Phpcq\ToolUpdate;
 
 use Phpcq\Exception\RuntimeException;
 use Phpcq\FileDownloader;
-use Phpcq\Platform\PlatformInformationInterface;
 use Phpcq\PluginApi\Version10\OutputInterface;
 use Phpcq\Repository\InstalledBootstrap;
 use Phpcq\Repository\JsonRepositoryDumper;
@@ -32,19 +31,8 @@ final class UpdateExecutor
      */
     private $output;
 
-    /**
-     * @var PlatformInformationInterface
-     */
-    private $platform;
-
-    public function __construct(
-        PlatformInformationInterface $platform,
-        FileDownloader $downloader,
-        string $phpcqPath,
-        OutputInterface $output
-    )
+    public function __construct(FileDownloader $downloader, string $phpcqPath, OutputInterface $output)
     {
-        $this->platform   = $platform;
         $this->downloader = $downloader;
         $this->phpcqPath  = $phpcqPath;
         $this->output     = $output;
@@ -52,7 +40,7 @@ final class UpdateExecutor
 
     public function execute(array $tasks): void
     {
-        $installed = new Repository($this->platform);
+        $installed = new Repository();
         foreach ($tasks as $task) {
             switch ($task['type']) {
                 case 'keep':

--- a/tests/Platform/PlatformInformationTest.php
+++ b/tests/Platform/PlatformInformationTest.php
@@ -7,6 +7,9 @@ namespace Platform;
 use Phpcq\Platform\PlatformInformation;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Phpcq\Platform\PlatformInformation
+ */
 class PlatformInformationTest extends TestCase
 {
     public function testCustomValues(): void
@@ -75,5 +78,16 @@ class PlatformInformationTest extends TestCase
         $this->assertSame('1.0.0', $platformInformation->getInstalledVersion('lib-ICU'));
         $this->assertSame('7.68.0', $platformInformation->getInstalledVersion('lib-curl'));
         $this->assertNull($platformInformation->getInstalledVersion('lib-foo'));
+    }
+
+    public function testMysqlndWorkaround(): void
+    {
+        if (!in_array('mysqlnd', get_loaded_extensions())) {
+            $this->markTestSkipped('mysqlnd extension is not loaded, can not test.');
+        }
+
+        $platformInformation = PlatformInformation::createFromCurrentPlatform();
+        // NOTE: as mysqlnd is bundled with php, we expect the same version here.
+        $this->assertSame(PHP_VERSION, $platformInformation->getInstalledVersion('ext-mysqlnd'));
     }
 }

--- a/tests/Platform/PlatformInformationTest.php
+++ b/tests/Platform/PlatformInformationTest.php
@@ -87,7 +87,19 @@ class PlatformInformationTest extends TestCase
         }
 
         $platformInformation = PlatformInformation::createFromCurrentPlatform();
-        // NOTE: as mysqlnd is bundled with php, we expect the same version here.
-        $this->assertSame(PHP_VERSION, $platformInformation->getInstalledVersion('ext-mysqlnd'));
+        if (version_compare(PHP_VERSION, '7.4.0', '>=')) {
+            // NOTE: as mysqlnd is bundled with php, we expect the same version here.
+            self::assertSame(PHP_VERSION, $platformInformation->getInstalledVersion('ext-mysqlnd'));
+            return;
+        }
+        // Allow to validate for older PHP versions.
+        self::assertContains($platformInformation->getInstalledVersion('ext-mysqlnd'), [
+            // Since PHP 7.4.0RC1
+            PHP_VERSION,
+            // Since PHP 7.0.0-alpha1: "mysqlnd 5.0.12-dev - 20150407 - $Id$"
+            '5.0.12-dev',
+            // Since PHP 5.5.0-alpha1: "mysqlnd 5.0.11-dev - 20120503 - $Id$"
+            '5.0.11-dev',
+        ]);
     }
 }

--- a/tests/Platform/PlatformRequirementCheckerTest.php
+++ b/tests/Platform/PlatformRequirementCheckerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Platform;
+
+use Phpcq\Platform\PlatformInformation;
+use Phpcq\Platform\PlatformInformationInterface;
+use Phpcq\Platform\PlatformRequirementChecker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Phpcq\Platform\PlatformRequirementChecker
+ */
+class PlatformRequirementCheckerTest extends TestCase
+{
+    public function testChecksAgainstPlatformInformation(): void
+    {
+        $platform = $this->getMockForAbstractClass(PlatformInformationInterface::class);
+        $checker  = PlatformRequirementChecker::create($platform);
+
+        $platform->method('getInstalledVersion')->with('php')->willReturn('1.0.0');
+
+        self::assertTrue($checker->isFulfilled('php', '^1.0.0'));
+        self::assertFalse($checker->isFulfilled('php', '^2.0.0'));
+    }
+
+    public function currentPlatformProvider(): array
+    {
+        $platform = PlatformInformation::createFromCurrentPlatform();
+        $result = [];
+        foreach ($platform->getExtensions() as $extension => $version) {
+            $result[] = [$extension, '^' . $version];
+        }
+        foreach ($platform->getLibraries() as $library => $version) {
+            $result[] = [$library, '^' . $version];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @dataProvider currentPlatformProvider
+     */
+    public function testCreatesCurrentPlatformInformationIfNonPassed(string $name, string $constraint): void
+    {
+        $checker = PlatformRequirementChecker::create();
+
+        self::assertTrue($checker->isFulfilled($name, $constraint));
+    }
+
+    public function testCreateAlwaysFulfillingFulfillsAnything(): void
+    {
+        $checker = PlatformRequirementChecker::createAlwaysFulfilling();
+
+        self::assertTrue($checker->isFulfilled('php', '^0.0.0'));
+        self::assertTrue($checker->isFulfilled('ext-unknown', '^0.0.0'));
+    }
+}

--- a/tests/Plugin/PluginRegistryTest.php
+++ b/tests/Plugin/PluginRegistryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phpcq\Test\Plugin;
 
-use Phpcq\Platform\PlatformInformationInterface;
 use Phpcq\Plugin\PluginRegistry;
 use Phpcq\PluginApi\Version10\PluginInterface;
 use Phpcq\Repository\InstalledBootstrap;
@@ -19,9 +18,7 @@ class PluginRegistryTest extends TestCase
 {
     public function testLoadFromInstalledRepository(): void
     {
-        $platform = $this->getMockForAbstractClass(PlatformInformationInterface::class);
-
-        $repository = new Repository($platform);
+        $repository = new Repository();
         $repository->addVersion($tool1 = $this->getMockForAbstractClass(ToolInformationInterface::class));
         $repository->addVersion($tool2 = $this->getMockForAbstractClass(ToolInformationInterface::class));
 

--- a/tests/Repository/InstalledRepositoryLoaderTest.php
+++ b/tests/Repository/InstalledRepositoryLoaderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Phpcq\Test\Repository;
 
 use Phpcq\Exception\RuntimeException;
-use Phpcq\Platform\PlatformInformation;
+use Phpcq\Platform\PlatformRequirementChecker;
 use Phpcq\Repository\InstalledBootstrap;
 use Phpcq\Repository\InstalledRepositoryLoader;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +17,7 @@ class InstalledRepositoryLoaderTest extends TestCase
 {
     public function testLoading(): void
     {
-        $instance = new InstalledRepositoryLoader(PlatformInformation::createFromCurrentPlatform());
+        $instance = new InstalledRepositoryLoader(PlatformRequirementChecker::create());
         $repository = $instance->loadFile(__DIR__ . '/../fixtures/repositories/installed-repository/installed.json');
 
         $this->assertTrue($repository->hasTool('phar-1', '^1.0.0'));
@@ -27,7 +27,7 @@ class InstalledRepositoryLoaderTest extends TestCase
 
     public function testLoadingFromRelativePath(): void
     {
-        $instance = new InstalledRepositoryLoader(PlatformInformation::createFromCurrentPlatform());
+        $instance = new InstalledRepositoryLoader(PlatformRequirementChecker::create());
         $repository = $instance->loadFile('installed.json', __DIR__ . '/../fixtures/repositories/installed-repository');
 
         $this->assertTrue($repository->hasTool('phar-1', '^1.0.0'));
@@ -37,7 +37,7 @@ class InstalledRepositoryLoaderTest extends TestCase
 
     public function testLoadingForNonExistingRelativePath(): void
     {
-        $instance = new InstalledRepositoryLoader(PlatformInformation::createFromCurrentPlatform());
+        $instance = new InstalledRepositoryLoader(PlatformRequirementChecker::create());
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('File not found: ./installed.json');
@@ -47,7 +47,7 @@ class InstalledRepositoryLoaderTest extends TestCase
 
     public function testLoadingForNonExistingRelativePathWithBaseDir(): void
     {
-        $instance = new InstalledRepositoryLoader(PlatformInformation::createFromCurrentPlatform());
+        $instance = new InstalledRepositoryLoader(PlatformRequirementChecker::create());
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('File not found: /does/not/exist/installed.json');
@@ -57,7 +57,7 @@ class InstalledRepositoryLoaderTest extends TestCase
 
     public function testLoadingForNonExistingAbsolutePath(): void
     {
-        $instance = new InstalledRepositoryLoader(PlatformInformation::createFromCurrentPlatform());
+        $instance = new InstalledRepositoryLoader(PlatformRequirementChecker::create());
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('File not found: /does/not/exist/installed.json');

--- a/tests/Repository/JsonRepositoryLoaderTest.php
+++ b/tests/Repository/JsonRepositoryLoaderTest.php
@@ -6,7 +6,7 @@ namespace Phpcq\Test\Repository;
 
 use Phpcq\Exception\RuntimeException;
 use Phpcq\FileDownloader;
-use Phpcq\Platform\PlatformInformationInterface;
+use Phpcq\Platform\PlatformRequirementCheckerInterface;
 use Phpcq\Repository\JsonRepositoryLoader;
 use Phpcq\Repository\RemoteBootstrap;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +27,6 @@ class JsonRepositoryLoaderTest extends TestCase
     public function testInvalidRepositoryThrows(): void
     {
         $fixture = __DIR__ . '/../fixtures/repositories/invalid/broken-url.json';
-        $platformInformation = $this->createMock(PlatformInformationInterface::class);
         $downloader = $this
             ->getMockBuilder(FileDownloader::class)
             ->disableOriginalConstructor()
@@ -47,7 +46,7 @@ class JsonRepositoryLoaderTest extends TestCase
                 throw new RuntimeException('Invalid URI passed: ' . $url);
             });
 
-        $loader = new JsonRepositoryLoader($platformInformation, $downloader);
+        $loader = new JsonRepositoryLoader(null, $downloader);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Invalid URI passed: 123');
@@ -59,13 +58,13 @@ class JsonRepositoryLoaderTest extends TestCase
     {
         $this->markTestSkipped('Not working with guzzle at the moment - needs to be rewritten when having factory.');
         $downloader = new FileDownloader(sys_get_temp_dir() . '/phpcq-test');
-        $platformInformation = $this->createMock(PlatformInformationInterface::class);
-        $platformInformation
-            ->method('getInstalledVersion')
-            ->willReturnArgument('php')
-            ->willReturn('5.6.1');
+        $requirementChecker = $this->createMock(PlatformRequirementCheckerInterface::class);
+        $requirementChecker
+            ->method('isFulfilled')
+            ->with('php', '5.6.1')
+            ->willReturn(true);
 
-        $loader = new JsonRepositoryLoader($platformInformation, $downloader);
+        $loader = new JsonRepositoryLoader($requirementChecker, $downloader);
         $repository = $loader->loadFile(__DIR__ . '/../fixtures/repositories/repository.json');
 
         // Test the included version exists.

--- a/tests/Repository/RemoteRepositoryTest.php
+++ b/tests/Repository/RemoteRepositoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Phpcq\Test\Repository;
 
 use Phpcq\FileDownloader;
-use Phpcq\Platform\PlatformInformationInterface;
 use Phpcq\Repository\JsonRepositoryLoader;
 use Phpcq\Repository\RemoteRepository;
 use PHPUnit\Framework\TestCase;
@@ -17,10 +16,9 @@ class RemoteRepositoryTest extends TestCase
 {
     public function testAddsVersionAndCanRetrieveVersion(): void
     {
-        $platformInformation = $this->createMock(PlatformInformationInterface::class);
-        $downloader          = $this->createMock(FileDownloader::class);
-        $loader              = new JsonRepositoryLoader($platformInformation, $downloader);
-        $repository          = new RemoteRepository('http://dummy/repository.json', $loader);
+        $downloader = $this->createMock(FileDownloader::class);
+        $loader     = new JsonRepositoryLoader(null, $downloader);
+        $repository = new RemoteRepository('http://dummy/repository.json', $loader);
 
         $downloader
             ->expects($this->once())
@@ -54,10 +52,9 @@ class RemoteRepositoryTest extends TestCase
 
     public function testEnumeratesAllVersions(): void
     {
-        $downloader          = $this->createMock(FileDownloader::class);
-        $platformInformation = $this->createMock(PlatformInformationInterface::class);
-        $loader              = new JsonRepositoryLoader($platformInformation, $downloader);
-        $repository          = new RemoteRepository('http://dummy/repository.json', $loader);
+        $downloader = $this->createMock(FileDownloader::class);
+        $loader     = new JsonRepositoryLoader(null, $downloader);
+        $repository = new RemoteRepository('http://dummy/repository.json', $loader);
 
         $downloader
             ->expects($this->once())

--- a/tests/Repository/RepositoryTest.php
+++ b/tests/Repository/RepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phpcq\Test\Repository;
 
-use Phpcq\Platform\PlatformInformationInterface;
+use Phpcq\Platform\PlatformRequirementCheckerInterface;
 use Phpcq\Repository\Repository;
 use Phpcq\Repository\ToolInformationInterface;
 use PHPUnit\Framework\TestCase;
@@ -16,8 +16,7 @@ class RepositoryTest extends TestCase
 {
     public function testAddsVersionAndCanRetrieveVersion(): void
     {
-        $platformInformation = $this->createMock(PlatformInformationInterface::class);
-        $repository = new Repository($platformInformation);
+        $repository = new Repository();
 
         $version = $this->createMock(ToolInformationInterface::class);
         $version->method('getVersion')->willReturn('1.0.0');
@@ -31,8 +30,7 @@ class RepositoryTest extends TestCase
 
     public function testEnumeratesAllVersions(): void
     {
-        $platformInformation = $this->createMock(PlatformInformationInterface::class);
-        $repository = new Repository($platformInformation);
+        $repository = new Repository();
 
         $version1 = $this->createMock(ToolInformationInterface::class);
         $version1->method('getVersion')->willReturn('1.0.0');
@@ -53,8 +51,16 @@ class RepositoryTest extends TestCase
 
     public function testAppliedPlatformInformation(): void
     {
-        $platformInformation = $this->createMock(PlatformInformationInterface::class);
-        $platformInformation->method('getInstalledVersion')->willReturn('5.6');
+        $platformInformation = $this->createMock(PlatformRequirementCheckerInterface::class);
+        $platformInformation
+            ->method('isFulfilled')
+            ->willReturnCallback(function (string $name, string $constraint): bool {
+                if ('php' !== $name) {
+                    return false;
+                }
+
+                return $constraint === '^5.6';
+            });
 
         $repository = new Repository($platformInformation);
 

--- a/tests/ToolUpdate/UpdateCalculatorTest.php
+++ b/tests/ToolUpdate/UpdateCalculatorTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Phpcq\Test\ToolUpdate;
 
-use Phpcq\Platform\PlatformInformationInterface;
 use Phpcq\PluginApi\Version10\OutputInterface;
 use Phpcq\Repository\Repository;
 use Phpcq\Repository\RepositoryInterface;
@@ -21,8 +20,8 @@ final class UpdateCalculatorTest extends TestCase
     public function testKeepsAlreadyCurrentTools(): void
     {
         $pool = new RepositoryPool();
-        $pool->addRepository($repository = new Repository($this->getMockForAbstractClass(PlatformInformationInterface::class)));
-        $installed = new Repository($this->getMockForAbstractClass(PlatformInformationInterface::class));
+        $pool->addRepository($repository = new Repository());
+        $installed = new Repository();
         $output    = $this->getMockForAbstractClass(OutputInterface::class);
 
         $output
@@ -105,8 +104,8 @@ final class UpdateCalculatorTest extends TestCase
     public function testUpgradesOutdatedTools(): void
     {
         $pool = new RepositoryPool();
-        $pool->addRepository($repository = new Repository($this->getMockForAbstractClass(PlatformInformationInterface::class)));
-        $installed = new Repository($this->getMockForAbstractClass(PlatformInformationInterface::class));
+        $pool->addRepository($repository = new Repository());
+        $installed = new Repository();
         $output    = $this->getMockForAbstractClass(OutputInterface::class);
 
         $output
@@ -147,8 +146,8 @@ final class UpdateCalculatorTest extends TestCase
     public function testDowngradesTools(): void
     {
         $pool = new RepositoryPool();
-        $pool->addRepository($repository = new Repository($this->getMockForAbstractClass(PlatformInformationInterface::class)));
-        $installed = new Repository($this->getMockForAbstractClass(PlatformInformationInterface::class));
+        $pool->addRepository($repository = new Repository());
+        $installed = new Repository();
         $output    = $this->getMockForAbstractClass(OutputInterface::class);
 
         $output
@@ -189,7 +188,7 @@ final class UpdateCalculatorTest extends TestCase
     public function testRemovesTools(): void
     {
         $pool = new RepositoryPool();
-        $installed = new Repository($this->getMockForAbstractClass(PlatformInformationInterface::class));
+        $installed = new Repository();
         $output    = $this->getMockForAbstractClass(OutputInterface::class);
 
         $output


### PR DESCRIPTION
This implements the `--ignore-platform-reqs` option as known from `composer`.

It has to be specified for all commands (except for `validate`), as all commands instantiate the `InstalledRepository` and other repositories, which filter the tool versions according to the platform constraints.