### PR TITLE
Fix namespace of Gnupg class in generated phar

### DIFF
--- a/.phpcq/phar/scoper.inc.php
+++ b/.phpcq/phar/scoper.inc.php
@@ -33,4 +33,13 @@ return [
         '\Symfony\Polyfill\*',
     ],
     'files-whitelist' => $symfonyPolyfill,
+    'patchers' => [
+        static function (string $filePath, string $prefix, string $content): string {
+            if ($filePath === 'vendor/phpcq/gnupg/src/GnuPGFactory.php') {
+                return str_replace('use ' . $prefix . '\Gnupg;', 'use Gnupg;', $content);
+            }
+
+            return $content;
+        }
+    ]
 ];


### PR DESCRIPTION
Using the gnupg php extension in the built phar is broken right now. Box prefixes the global class `\Gnupg` and there is no way to whitelist the class. Therefore I added a patcher for it.