### PR TITLE
Use the task name instead of the plugin name for the reports

### DIFF
--- a/src/Command/ExecCommand.php
+++ b/src/Command/ExecCommand.php
@@ -100,6 +100,7 @@ final class ExecCommand extends AbstractCommand
         $environment = new Environment(
             $projectConfig,
             new SingleProcessTaskFactory(new TaskFactory(
+                $pluginName,
                 $installed->getPlugin($instance->getName()),
                 ...$this->findPhpCli()
             )),

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -221,6 +221,7 @@ final class RunCommand extends AbstractCommand
         $environment = new Environment(
             $projectConfig,
             new TaskFactory(
+                $taskName,
                 $installed->getPlugin($plugin->getName()),
                 ...$this->findPhpCli()
             ),

--- a/src/Console/Definition/ExecTaskDefinitionBuilder.php
+++ b/src/Console/Definition/ExecTaskDefinitionBuilder.php
@@ -102,6 +102,7 @@ final class ExecTaskDefinitionBuilder implements ExecTaskDefinitionBuilderInterf
         return new Environment(
             $this->projectConfig,
             new SingleProcessTaskFactory(new TaskFactory(
+                $plugin->getName(),
                 $this->installed->getPlugin($plugin->getName()),
                 ...$this->phpCli
             )),

--- a/src/Report/Writer/ConsoleWriter.php
+++ b/src/Report/Writer/ConsoleWriter.php
@@ -109,13 +109,13 @@ final class ConsoleWriter
             $metadata = $taskReport->getMetadata();
             $rows[] = [
                 $taskReport->getTaskName(),
-                $taskReport->getMetadata()['plugin_name'],
+                ($taskReport->getMetadata()['tool_name'] ?? ''),
                 ($metadata['tool_version'] ?? ''),
                 $this->renderToolStatus($taskReport->getStatus()),
             ];
         }
 
-        $this->style->table(['Task', 'Plugin', 'Version', 'State'], $rows);
+        $this->style->table(['Task', 'Tool', 'Version', 'State'], $rows);
     }
 
     private function writeEntryReport(DiagnosticIteratorEntry $entry): void

--- a/src/Task/TaskFactory.php
+++ b/src/Task/TaskFactory.php
@@ -13,11 +13,14 @@ use Phpcq\Runner\Repository\InstalledPlugin;
 class TaskFactory implements TaskFactoryInterface
 {
     /**
-     * The installed repository.
+     * The installed plugin.
      *
      * @var InstalledPlugin
      */
     private $installed;
+
+    /** @var string */
+    private $taskName;
 
     /** @var string */
     private $phpCliBinary;
@@ -33,10 +36,12 @@ class TaskFactory implements TaskFactoryInterface
      * @param list<string>    $phpArguments
      */
     public function __construct(
+        string $taskName,
         InstalledPlugin $installed,
         string $phpCliBinary,
         array $phpArguments
     ) {
+        $this->taskName     = $taskName;
         $this->installed    = $installed;
         $this->phpCliBinary = $phpCliBinary;
         $this->phpArguments = $phpArguments;
@@ -49,7 +54,7 @@ class TaskFactory implements TaskFactoryInterface
      */
     public function buildRunProcess(string $toolName, array $command): TaskBuilderInterface
     {
-        return new TaskBuilder($toolName, array_values($command), $this->getMetadata($toolName));
+        return new TaskBuilder($this->taskName, array_values($command), $this->getMetadata($toolName));
     }
 
     /**
@@ -77,7 +82,7 @@ class TaskFactory implements TaskFactoryInterface
     public function buildPhpProcess(string $toolName, array $arguments = []): PhpTaskBuilderInterface
     {
         return new TaskBuilderPhp(
-            $toolName,
+            $this->taskName,
             $this->phpCliBinary,
             $this->phpArguments,
             array_values($arguments),

--- a/tests/Task/TaskFactoryTest.php
+++ b/tests/Task/TaskFactoryTest.php
@@ -24,6 +24,7 @@ final class TaskFactoryTest extends TestCase
         $tool->method('getName')->willReturn('task-name');
 
         $factory = new TaskFactory(
+            'test',
             new InstalledPlugin($this->getMockForAbstractClass(PluginVersionInterface::class), [$tool]),
             '/path/to/php-cli',
             ['php', 'arguments']
@@ -41,6 +42,7 @@ final class TaskFactoryTest extends TestCase
         $tool->method('getName')->willReturn('phar-name');
 
         $factory = new TaskFactory(
+            'test',
             new InstalledPlugin($this->getMockForAbstractClass(PluginVersionInterface::class), [$tool]),
             '/path/to/php-cli',
             ['php', 'arguments']
@@ -62,6 +64,7 @@ final class TaskFactoryTest extends TestCase
         $tool->method('getName')->willReturn('task-name');
 
         $factory = new TaskFactory(
+            'task-name',
             new InstalledPlugin($this->getMockForAbstractClass(PluginVersionInterface::class), [$tool]),
             '/path/to/php-cli',
             ['php', 'arguments']


### PR DESCRIPTION
This pull request fixes the issue that a tool report might be overridden when running the same plugin twice with different configuration.

It also drops the plugin from the console report overview but only shows the tool and the tool version.