### PR TITLE
Build versioned phar

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  - commit-message:
+      include: "scope"
+      prefix: "composer"
+    directory: "/"
+    open-pull-requests-limit: 10
+    package-ecosystem: "composer"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: "increase"
+
+  - commit-message:
+      include: "scope"
+      prefix: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-unstable-phar.yml
+++ b/.github/workflows/build-unstable-phar.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Pull source
         uses: actions/checkout@v2
 
+      # We need the tags for the @git-version@ placeholder used by box
+      # See https://github.com/actions/checkout/issues/701
+      - name: Fetch git tags
+        run: git fetch --tags origin
+
       - name: Setup PHP with PECL extension
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
The current build with github action does not contain the `@git-version@`. This is caused by `actions/checkout@v2` which does not get the git tags.